### PR TITLE
Use a Standard-Compliant License Identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mocha": "1.17.1"
   },
   "author": "David Burns",
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/AutomatedTester/mathext-js/issues"
   },


### PR DESCRIPTION
This pull request changes the value of the license property in `package.json` to a standard, machine-readable SPDX license identifier.

I'll be honest: This is a semi-automated pull request. I started by using [dat](http://dat-data.com/) and [dat-npm](https://www.npmjs.com/package/dat-npm) to review metadata for all packages on [npm](http://npmjs.com), looking for packages updated sometime in the last year that don't use a valid [SPDX license identifier](https://spdx.org/licenses/) in `package.json`. I used my own npm module, [spdx-correct](https://github.com/kemitchell/spdx-correct.js) to guess what license you were after: [`"Apache-2.0"`](https://spdx.org/licenses/Apache-2.0). A quick manual check and a few shell scripts later, and this pull request was born.

npm doesn't require that you use a valid SPDX identifier, but it's strongly recommended. (Try `npm help 7 package.json` and search for “License”.) Other source code package managers, like Maven for Java and RubyGems for Ruby, recommend the same. 

Why care about SPDX? A machine-readable standard makes it possible for programs, rather than just people, to review a module or even an entire codebase to make sure that licenses are compatible. Whatever the reason—strong personal conviction, company policy, terms of a business deal—SPDX makes it easier to collaborate with others when licenses can be a problem, and helps take open-source software to more places. Given that [npm has a ton of modules](http://www.modulecounts.com/) but also handles dependencies in a novel way, I think a little license hygiene could help npm build amazing new relationships between communities that lawyers have long kept apart.

Though this PR was semi-automatic, my responses to any questions you have won't be. I can't give legal advice over GitHub, but I'm happy to answer questions about SPDX or point you to good resources on related problems.

Thanks for your contribution to open-source software!

K
